### PR TITLE
Removed unused and deprecated tsparticles-shape-confetti

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,6 @@
         "tsparticles-engine": "^2.9.3",
         "tsparticles-preset-confetti": "^2.9.3",
         "tsparticles-preset-fireworks": "^2.9.3",
-        "tsparticles-shape-confetti": "^1.14.2",
         "yup": "^1.2.0"
       },
       "devDependencies": {
@@ -26034,32 +26033,6 @@
       "dependencies": {
         "tsparticles-engine": "^2.9.3"
       }
-    },
-    "node_modules/tsparticles-shape-confetti": {
-      "version": "1.14.2",
-      "resolved": "https://registry.npmjs.org/tsparticles-shape-confetti/-/tsparticles-shape-confetti-1.14.2.tgz",
-      "integrity": "sha512-JKS8GcAJX54b5xD4m/CkZaiQ7E3oBPQcpr4oAJOVrWIFWekEgEnYlHIIsNgb7hzAoUFeEJqYSu/rkRNnM5/+UQ==",
-      "deprecated": "tsParticles has more realistic effects with version 1.30",
-      "dependencies": {
-        "tsparticles": "^1.29.2"
-      }
-    },
-    "node_modules/tsparticles-shape-confetti/node_modules/tsparticles": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/tsparticles/-/tsparticles-1.43.1.tgz",
-      "integrity": "sha512-6EuHncwqzoyTlUxc11YH8LVlwVUgpYaZD0yMOeA2OvRqFZ9VQV8EjjQ6ZfXt6pfGA1ObPwU929jveFatxwTQkg==",
-      "deprecated": "tsParticles 2.6.0 is out, please update",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/matteobruni"
-        },
-        {
-          "type": "buymeacoffee",
-          "url": "https://www.buymeacoffee.com/matteobruni"
-        }
-      ],
-      "hasInstallScript": true
     },
     "node_modules/tsparticles-shape-image": {
       "version": "2.9.3",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "tsparticles-engine": "^2.9.3",
     "tsparticles-preset-confetti": "^2.9.3",
     "tsparticles-preset-fireworks": "^2.9.3",
-    "tsparticles-shape-confetti": "^1.14.2",
     "yup": "^1.2.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12838,13 +12838,6 @@ tsparticles-shape-circle@^2.9.3:
   dependencies:
     tsparticles-engine "^2.9.3"
 
-tsparticles-shape-confetti@^1.14.2:
-  version "1.14.2"
-  resolved "https://registry.npmjs.org/tsparticles-shape-confetti/-/tsparticles-shape-confetti-1.14.2.tgz"
-  integrity sha512-JKS8GcAJX54b5xD4m/CkZaiQ7E3oBPQcpr4oAJOVrWIFWekEgEnYlHIIsNgb7hzAoUFeEJqYSu/rkRNnM5/+UQ==
-  dependencies:
-    tsparticles "^1.29.2"
-
 tsparticles-shape-image@^2.9.3:
   version "2.9.3"
   resolved "https://registry.npmjs.org/tsparticles-shape-image/-/tsparticles-shape-image-2.9.3.tgz"


### PR DESCRIPTION
<https://www.npmjs.com/package/tsparticles-shape-confetti> was deprecated long time ago, since here is used [tsParticles](https://particles.js.org) v2, importing that old package too is useless.